### PR TITLE
Jsonfile doesn't behave nicely when used inside a test suite.

### DIFF
--- a/lib/jsonfile.js
+++ b/lib/jsonfile.js
@@ -35,8 +35,8 @@ me.writeFile = function(file, obj, options, callback) {
   } catch (err) {
     if (callback) {
       callback(err, null);
-      return;
     }
+    return;
   }
   fs.writeFile(file, str, options, callback);
 }


### PR DESCRIPTION
If you create a minimal npm project with just async and jsonfile as dependencies and execute the following code

``` javascript
var assert, async, jsonfile;
assert = require('assert');
async = require('async');
jsonfile = require('jsonfile');
async.map(['package.json'], jsonfile.readFile, function (err, results) {
  assert(!err);
  assert(results.length === 2);
});
```

It will fail with

```
project/node_modules/async/lib/async.js:22
            if (called) throw new Error("Callback was already called.");
                              ^
Error: Callback was already called.
  at project/node_modules/async/lib/async.js:22:31
  at project/node_modules/async/lib/async.js:226:17
  at project/node_modules/jsonfile/lib/jsonfile.js:15:7
  at fs.js:266:14
  at Object.oncomplete (fs.js:107:15)
```

instead than the expected

```
assert.js:92
  throw new assert.AssertionError({
        ^
AssertionError: false == true
```

(expected because the second assertion is plain wrong).

That happens because async throws an error if the final callback gets called more than once. But because the assert throws an AssertionError, the catch clause at https://github.com/jprichardson/node-jsonfile/blob/master/lib/jsonfile.js#L15 calls the same callback one more time, causing the wrong error message (and a headache worth an afternoon)

The proposed code fixes the issue
