### PR TITLE
Added try,catch to readFileSync

### DIFF
--- a/lib/jsonfile.js
+++ b/lib/jsonfile.js
@@ -20,7 +20,11 @@ me.readFile = function(file, callback) {
 }
 
 me.readFileSync = function(file) {
-  return JSON.parse(fs.readFileSync(file, 'utf8'));
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch( err ) {
+    return null
+  }  
 }
 
 me.writeFile = function(file, obj, options, callback) {


### PR DESCRIPTION
While readFile is safe, JSON parser in readFileSync can throw exception. Try, catch should solve this issue.
