### PR TITLE
Add EOL at EOF

### DIFF
--- a/lib/jsonfile.js
+++ b/lib/jsonfile.js
@@ -36,7 +36,7 @@ me.writeFile = function(file, obj, options, callback) {
 
   var str = ''
   try {
-    str = JSON.stringify(obj, null, me.spaces)
+    str = JSON.stringify(obj, null, me.spaces) + '\n';
   } catch (err) {
     if (callback) return callback(err, null)
   }
@@ -45,6 +45,6 @@ me.writeFile = function(file, obj, options, callback) {
 }
 
 me.writeFileSync = function(file, obj, options) {
-  var str = JSON.stringify(obj, null, me.spaces)
+  var str = JSON.stringify(obj, null, me.spaces) + '\n';
   return fs.writeFileSync(file, str, options) //not sure if fs.writeFileSync returns anything, but just in case
 }

--- a/test/jsonfile.test.js
+++ b/test/jsonfile.test.js
@@ -37,6 +37,19 @@ test('- writeFile()', function(done) {
   })
 })
 
+test('- writeFile() adds EOL at EOF', function(done) {
+  var file = path.join(TEST_DIR, 'eol.json')
+  var obj = {name: 'JP'}
+
+  jf.writeFile(file, obj, function(err) {
+    F (err)
+    fs.readFile(file, 'utf8', function(err,data) {
+      T (data[data.length-1] === '\n')
+      done()
+    })
+  })
+})
+
 test('- readFileSync()', function(done) {
   var file = path.join(TEST_DIR, 'somefile3.json')
   var obj = {name: 'JP'}
@@ -62,3 +75,13 @@ test('- writeFileSync()', function(done) {
   done()
 })
 
+test('- writeFileSync() adds EOL at EOF', function(done) {
+  var file = path.join(TEST_DIR, 'eol-sync.json')
+  var obj = {name: 'JP'}
+
+  jf.writeFileSync(file, obj)
+
+  var data = fs.readFileSync(file, 'utf8')
+  T (data[data.length-1] === '\n')
+  done()
+})


### PR DESCRIPTION
Write a newline character at the end of the file written, because
EOL should be treated as "line terminator", not "line separator".

Close #13.
