### PR TITLE
export spaces defaulted to null

### DIFF
--- a/lib/jsonfile.js
+++ b/lib/jsonfile.js
@@ -2,7 +2,7 @@ var fs = require('fs')
 
 var me = module.exports
 
-me.spaces = 2
+me.spaces = null
 
 me.readFile = function(file, options, callback) {
   if (callback == undefined) {


### PR DESCRIPTION
Solves [issue #15](https://github.com/jprichardson/node-jsonfile/issues/15).

`jsonfile` is basically a wrapper to `JSON` with additional functionality from `fs`. Thus, it should show the same behavior as `JSON`. When [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) is not supplied with an argument for `spaces`, it will not beautify the JSON output. Similarly, `jsonfile` should default to _not_ beautifying the JSON output.
