### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,7 @@
     "json"
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": ""
-    }
-  ],
+  "license": "MIT",
   "dependencies": {},
   "devDependencies": {
     "testutil": "^0.7.0",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/