### PR TITLE
[Modify] Support string include is unicode escape string

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ function readFile (file, options, callback) {
     options = {}
   }
 
+  var self = this
   fs.readFile(file, options, function (err, data) {
     if (err) return callback(err)
 
     var obj
     try {
-      obj = JSON.parse(data, options ? options.reviver : null)
+      obj = JSON.parse(self.decodeStr(data), options ? options.reviver : null)
     } catch (err2) {
       return callback(err2)
     }
@@ -29,10 +30,10 @@ function readFileSync (file, options) {
   var shouldThrow = 'throws' in options ? options.throw : true
 
   if (shouldThrow) { // i.e. throw on invalid JSON
-    return JSON.parse(fs.readFileSync(file, options), options.reviver)
+    return JSON.parse(this.decodeStr(fs.readFileSync(file, options)), options.reviver)
   } else {
     try {
-      return JSON.parse(fs.readFileSync(file, options), options.reviver)
+      return JSON.parse(this.decodeStr(fs.readFileSync(file, options)), options.reviver)
     } catch (err) {
       return null
     }
@@ -73,12 +74,22 @@ function writeFileSync (file, obj, options) {
   return fs.writeFileSync(file, str, options)
 }
 
+function decodeStr (str) {
+  if (typeof str === 'string') {
+    return unescape(str.replace(/\\u([\dA-F]{4})/gi, function (match, charCode) {
+      return String.fromCharCode(parseInt(charCode, 16))
+    }))
+  }
+  return str
+}
+
 var jsonfile = {
   spaces: null,
   readFile: readFile,
   readFileSync: readFileSync,
   writeFile: writeFile,
-  writeFileSync: writeFileSync
+  writeFileSync: writeFileSync,
+  decodeStr: decodeStr
 }
 
 module.exports = jsonfile

--- a/test.js
+++ b/test.js
@@ -92,6 +92,45 @@ describe('jsonfile', function () {
         })
       })
     })
+    describe('> when passing encoding string as option', function () {
+      it('should not throw an error', function (done) {
+        var file = path.join(TEST_DIR, 'somefile.json')
+
+        var obj = {
+          name: 'jp'
+        }
+        fs.writeFileSync(file, JSON.stringify(obj))
+
+        jf.readFile(file, 'utf8', function (err) {
+          assert.ifError(err)
+          assert.strictEqual(obj.name, 'jp')
+          done()
+        })
+      })
+    })
+
+    describe('> when  passing through the decodeStr', function () {
+      it('should read and parse JSON', function (done) {
+        var file = path.join(TEST_DIR, 'somefile.json')
+
+        var obj = {
+          name: '\u5fcd',
+          ruby: 'SHINOBI'
+        }
+
+        fs.writeFileSync(file, JSON.stringify(obj))
+
+        jf.readFile(file, function (err, obj) {
+          assert.ifError(err)
+          var actual = jf.decodeStr(obj)
+          var expectedOfName = '忍'
+          var expectedOfRuby = 'SHINOBI'
+          assert.equal(actual.name, expectedOfName)
+          assert.equal(actual.ruby, expectedOfRuby)
+          done()
+        })
+      })
+    })
   })
 
   describe('+ readFileSync()', function () {
@@ -160,6 +199,30 @@ describe('jsonfile', function () {
           assert.ifError(err)
         }
         assert.strictEqual(data.name, 'jp')
+      })
+    })
+
+    describe('> when passing through the decodeStr', function () {
+      it('should read and parse JSON', function (done) {
+        var file = path.join(TEST_DIR, 'somefile.json')
+
+        var obj = {
+          name: '\u5fcd',
+          ruby: 'SHINOBI'
+        }
+
+        fs.writeFileSync(file, JSON.stringify(obj))
+
+        try {
+          var actual = jf.readFileSync(file, 'utf8')
+        } catch (err) {
+          assert.ifError(err)
+        }
+        var expectedOfName = '忍'
+        var expectedOfRuby = 'SHINOBI'
+        assert.equal(actual.name, expectedOfName)
+        assert.equal(actual.ruby, expectedOfRuby)
+        done()
       })
     })
   })
@@ -340,4 +403,25 @@ describe('jsonfile', function () {
       assert.strictEqual(jf.spaces, null)
     })
   })
+
+  describe('+ decodeStr()', function () {
+    describe('> when passing decoding target type is string', function () {
+      it('should arguments type is string', function () {
+        var argument = '{ name: "\u5fcd" }'
+        var actual = jf.decodeStr(argument)
+        var expected = '{ name: "忍" }'
+        assert.equal(actual, expected)
+      })
+    })
+
+    describe('> when passing decoding target type is string', function () {
+      it('should arguments type is not string', function () {
+        var argument = 1986
+        var actual = jf.decodeStr(argument)
+        var expected = 1986
+        assert.equal(actual, expected)
+      })
+    })
+  })
+
 })


### PR DESCRIPTION
Nice to meet you. jprichardson.

It corresponds to the case where the string contains Unicode escape.
because JSON.parse  does not support the string containing the Unicode escape.

Does this code could you accept?
Please consider.
