### PR TITLE
Add `throws` option for readFile (async)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,12 @@ function readFile (file, options, callback) {
     options = {}
   }
 
-  var shouldThrow = 'throws' in options ? options.throws : true
+  var shouldThrow
+  try {
+    shouldThrow = 'throws' in options ? options.throws : true
+  } catch (e) {
+    shouldThrow = true
+  }
 
   fs.readFile(file, options, function (err, data) {
     if (err) return callback(err)

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ function readFile (file, options, callback) {
     options = {}
   }
 
+  var shouldThrow = 'throws' in options ? options.throws : true
+
   fs.readFile(file, options, function (err, data) {
     if (err) return callback(err)
 
@@ -13,8 +15,12 @@ function readFile (file, options, callback) {
     try {
       obj = JSON.parse(data, options ? options.reviver : null)
     } catch (err2) {
-      err2.message = file + ': ' + err2.message
-      return callback(err2)
+      if (shouldThrow) {
+        err2.message = file + ': ' + err2.message
+        return callback(err2)
+      } else {
+        return callback(null, null)
+      }
     }
 
     callback(null, obj)

--- a/index.js
+++ b/index.js
@@ -6,11 +6,19 @@ function readFile (file, options, callback) {
     options = {}
   }
 
-  var shouldThrow
-  try {
-    shouldThrow = 'throws' in options ? options.throws : true
-  } catch (e) {
-    shouldThrow = true
+  if (typeof options === 'string') {
+    options = {encoding: options}
+  }
+
+  if (options == null) {
+    options = {}
+  }
+
+  var shouldThrow = true
+  if ('errorOnFailedParse' in options) {
+    shouldThrow = options.errorOnFailedParse
+  } else if ('throws' in options) {
+    shouldThrow = options.throws
   }
 
   fs.readFile(file, options, function (err, data) {
@@ -38,7 +46,13 @@ function readFileSync (file, options) {
     options = {encoding: options}
   }
 
-  var shouldThrow = 'throws' in options ? options.throws : true
+  var shouldThrow = true
+  if ('errorOnFailedParse' in options) {
+    shouldThrow = options.errorOnFailedParse
+  } else if ('throws' in options) {
+    shouldThrow = options.throws
+  }
+
   var content = fs.readFileSync(file, options)
 
   try {

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ function readFile (file, options, callback) {
   }
 
   var shouldThrow = true
-  if ('errorOnFailedParse' in options) {
-    shouldThrow = options.errorOnFailedParse
+  if ('passParsingErrors' in options) {
+    shouldThrow = options.passParsingErrors
   } else if ('throws' in options) {
     shouldThrow = options.throws
   }
@@ -47,8 +47,8 @@ function readFileSync (file, options) {
   }
 
   var shouldThrow = true
-  if ('errorOnFailedParse' in options) {
-    shouldThrow = options.errorOnFailedParse
+  if ('passParsingErrors' in options) {
+    shouldThrow = options.passParsingErrors
   } else if ('throws' in options) {
     shouldThrow = options.throws
   }

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -49,7 +49,7 @@ describe('+ readFileSync()', function () {
     })
   })
 
-  describe('> when invalid JSON and errorOnFailedParse set to false', function () {
+  describe('> when invalid JSON and passParsingErrors set to false', function () {
     it('should return null', function () {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
       var data = '{not valid JSON'
@@ -59,7 +59,7 @@ describe('+ readFileSync()', function () {
         jf.readFileSync(file)
       })
 
-      var obj = jf.readFileSync(file, {errorOnFailedParse: false})
+      var obj = jf.readFileSync(file, {passParsingErrors: false})
       assert.strictEqual(obj, null)
     })
   })
@@ -79,7 +79,7 @@ describe('+ readFileSync()', function () {
     })
   })
 
-  describe('> when invalid JSON and errorOnFailedParse set to true', function () {
+  describe('> when invalid JSON and passParsingErrors set to true', function () {
     it('should return null', function () {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
       var data = '{not valid JSON'

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -49,6 +49,21 @@ describe('+ readFileSync()', function () {
     })
   })
 
+  describe('> when invalid JSON and errorOnFailedParse set to false', function () {
+    it('should return null', function () {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+      var data = '{not valid JSON'
+      fs.writeFileSync(file, data)
+
+      assert.throws(function () {
+        jf.readFileSync(file)
+      })
+
+      var obj = jf.readFileSync(file, {errorOnFailedParse: false})
+      assert.strictEqual(obj, null)
+    })
+  })
+
   describe('> when invalid JSON and throws set to false', function () {
     it('should return null', function () {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
@@ -61,6 +76,22 @@ describe('+ readFileSync()', function () {
 
       var obj = jf.readFileSync(file, {throws: false})
       assert.strictEqual(obj, null)
+    })
+  })
+
+  describe('> when invalid JSON and errorOnFailedParse set to true', function () {
+    it('should return null', function () {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+      var data = '{not valid JSON'
+      fs.writeFileSync(file, data)
+
+      assert.throws(function () {
+        jf.readFileSync(file)
+      })
+
+      assert.throws(function () {
+        jf.readFileSync(file, {throws: true})
+      })
     })
   })
 

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -46,7 +46,7 @@ describe('+ readFile()', function () {
     })
   })
 
-  describe('> when invalid JSON and errorOnFailedParse set to false', function () {
+  describe('> when invalid JSON and passParsingErrors set to false', function () {
     it('should return null and no error', function (done) {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
       var data = '{not valid JSON'
@@ -62,7 +62,7 @@ describe('+ readFile()', function () {
         bothDone = true
       })
 
-      jf.readFile(file, {errorOnFailedParse: false}, function (err, obj2) {
+      jf.readFile(file, {passParsingErrors: false}, function (err, obj2) {
         assert.ifError(err)
         assert.strictEqual(obj2, null)
         if (bothDone) {
@@ -100,7 +100,7 @@ describe('+ readFile()', function () {
     })
   })
 
-  describe('> when invalid JSON and errorOnFailedParse set to true', function () {
+  describe('> when invalid JSON and passParsingErrors set to true', function () {
     it('should return an error', function (done) {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
       var data = '{not valid JSON'
@@ -116,7 +116,7 @@ describe('+ readFile()', function () {
         bothDone = true
       })
 
-      jf.readFile(file, {errorOnFailedParse: true}, function (err, obj2) {
+      jf.readFile(file, {passParsingErrors: true}, function (err, obj2) {
         assert(err instanceof Error)
         assert(err.message.match(file))
         if (bothDone) {

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -46,6 +46,60 @@ describe('+ readFile()', function () {
     })
   })
 
+  describe('> when invalid JSON and throws set to false', function () {
+    it('should return null and no error', function (done) {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+      var data = '{not valid JSON'
+      var bothDone = false
+      fs.writeFileSync(file, data)
+
+      jf.readFile(file, function (err, obj2) {
+        assert(err instanceof Error)
+        assert(err.message.match(file))
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+
+      jf.readFile(file, {throws: false}, function (err, obj2) {
+        assert.ifError(err)
+        assert.strictEqual(obj2, null)
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+    })
+  })
+
+  describe('> when invalid JSON and throws set to true', function () {
+    it('should return an error', function (done) {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+      var data = '{not valid JSON'
+      var bothDone = false
+      fs.writeFileSync(file, data)
+
+      jf.readFile(file, function (err, obj2) {
+        assert(err instanceof Error)
+        assert(err.message.match(file))
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+
+      jf.readFile(file, {throws: true}, function (err, obj2) {
+        assert(err instanceof Error)
+        assert(err.message.match(file))
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+    })
+  })
+
   describe('> when JSON reviver is set', function () {
     it('should transform the JSON', function (done) {
       var file = path.join(TEST_DIR, 'somefile.json')

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -46,6 +46,33 @@ describe('+ readFile()', function () {
     })
   })
 
+  describe('> when invalid JSON and errorOnFailedParse set to false', function () {
+    it('should return null and no error', function (done) {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+      var data = '{not valid JSON'
+      var bothDone = false
+      fs.writeFileSync(file, data)
+
+      jf.readFile(file, function (err, obj2) {
+        assert(err instanceof Error)
+        assert(err.message.match(file))
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+
+      jf.readFile(file, {errorOnFailedParse: false}, function (err, obj2) {
+        assert.ifError(err)
+        assert.strictEqual(obj2, null)
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+    })
+  })
+
   describe('> when invalid JSON and throws set to false', function () {
     it('should return null and no error', function (done) {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
@@ -65,6 +92,33 @@ describe('+ readFile()', function () {
       jf.readFile(file, {throws: false}, function (err, obj2) {
         assert.ifError(err)
         assert.strictEqual(obj2, null)
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+    })
+  })
+
+  describe('> when invalid JSON and errorOnFailedParse set to true', function () {
+    it('should return an error', function (done) {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+      var data = '{not valid JSON'
+      var bothDone = false
+      fs.writeFileSync(file, data)
+
+      jf.readFile(file, function (err, obj2) {
+        assert(err instanceof Error)
+        assert(err.message.match(file))
+        if (bothDone) {
+          done()
+        }
+        bothDone = true
+      })
+
+      jf.readFile(file, {errorOnFailedParse: true}, function (err, obj2) {
+        assert(err instanceof Error)
+        assert(err.message.match(file))
         if (bothDone) {
           done()
         }


### PR DESCRIPTION
This maintains the behavior of readFileSync.
Just like an error actually reading the file would still throw, in this case it will still return the error to the callback.
If an error happens parsing the contents, the callback will no longer recieve an error, but `null` will be passed back to the callback for the object, just as the sync version returns `null` if it fails to parse. If the option is omitted (or still true) existing behavior will be maintained. 