### PR TITLE
Moved fs.readFileSync within the try/catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,10 +63,9 @@ function readFileSync (file, options) {
     shouldThrow = options.throws
   }
 
-  var content = fs.readFileSync(file, options)
-  content = stripBom(content)
-
   try {
+    var content = fs.readFileSync(file, options)
+    content = stripBom(content)
     return JSON.parse(content, options.reviver)
   } catch (err) {
     if (shouldThrow) {

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -98,14 +98,29 @@ describe('+ readFileSync()', function () {
   })
 
   describe('> when invalid JSON and throws set to true', function () {
-    it('should return null', function () {
+    it('should throw an exception', function () {
       var file = path.join(TEST_DIR, 'somefile4-invalid.json')
       var data = '{not valid JSON'
       fs.writeFileSync(file, data)
 
       assert.throws(function () {
-        jf.readFileSync(file)
+        jf.readFileSync(file, {throws: true})
       })
+    })
+  })
+
+  describe('> when json file is missing and throws set to false', function () {
+    it('should return null', function () {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
+
+      var obj = jf.readFileSync(file, {throws: false})
+      assert.strictEqual(obj, null)
+    })
+  })
+
+  describe('> when json file is missing and throws set to true', function () {
+    it('should throw an exception', function () {
+      var file = path.join(TEST_DIR, 'somefile4-invalid.json')
 
       assert.throws(function () {
         jf.readFileSync(file, {throws: true})


### PR DESCRIPTION
Moved readFileSync within the try/catch to prevent filesystem errors when a file was not present. The error when throws is true is the same as before, but when it's false the error is swallowed and the return is null.
