### PR TITLE
Fix test for Node.js v6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "io.js"
   - "4"
   - "5"
+  - "6"
 matrix:
   include:
     - node_js: "4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "5"
+    - nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -13,13 +13,13 @@ describe('+ readFileSync()', function () {
 
   beforeEach(function (done) {
     TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-readfile-sync')
-    rimraf(TEST_DIR, function () {
-      fs.mkdir(TEST_DIR, done)
-    })
+    rimraf.sync(TEST_DIR)
+    fs.mkdir(TEST_DIR, done)
   })
 
   afterEach(function (done) {
-    rimraf(TEST_DIR, done)
+    rimraf.sync(TEST_DIR)
+    done()
   })
 
   it('should read and parse JSON', function () {

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -13,13 +13,13 @@ describe('+ readFile()', function () {
 
   beforeEach(function (done) {
     TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-readfile')
-    rimraf(TEST_DIR, function () {
-      fs.mkdir(TEST_DIR, done)
-    })
+    rimraf.sync(TEST_DIR)
+    fs.mkdir(TEST_DIR, done)
   })
 
   afterEach(function (done) {
-    rimraf(TEST_DIR, done)
+    rimraf.sync(TEST_DIR)
+    done()
   })
 
   it('should read and parse JSON', function (done) {

--- a/test/test.js
+++ b/test/test.js
@@ -12,13 +12,13 @@ describe('jsonfile', function () {
 
   beforeEach(function (done) {
     TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests')
-    rimraf(TEST_DIR, function () {
-      fs.mkdir(TEST_DIR, done)
-    })
+    rimraf.sync(TEST_DIR)
+    fs.mkdir(TEST_DIR, done)
   })
 
   afterEach(function (done) {
-    rimraf(TEST_DIR, done)
+    rimraf.sync(TEST_DIR)
+    done()
   })
 
   describe('spaces', function () {

--- a/test/write-file-sync.test.js
+++ b/test/write-file-sync.test.js
@@ -13,13 +13,13 @@ describe('+ writeFileSync()', function () {
 
   beforeEach(function (done) {
     TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-writefile-sync')
-    rimraf(TEST_DIR, function () {
-      fs.mkdir(TEST_DIR, done)
-    })
+    rimraf.sync(TEST_DIR)
+    fs.mkdir(TEST_DIR, done)
   })
 
   afterEach(function (done) {
-    rimraf(TEST_DIR, done)
+    rimraf.sync(TEST_DIR)
+    done()
   })
 
   it('should serialize the JSON and write it to file', function () {

--- a/test/write-file.test.js
+++ b/test/write-file.test.js
@@ -13,13 +13,13 @@ describe('+ writeFile()', function () {
 
   beforeEach(function (done) {
     TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-writefile')
-    rimraf(TEST_DIR, function () {
-      fs.mkdir(TEST_DIR, done)
-    })
+    rimraf.sync(TEST_DIR)
+    fs.mkdir(TEST_DIR, done)
   })
 
   afterEach(function (done) {
-    rimraf(TEST_DIR, done)
+    rimraf.sync(TEST_DIR)
+    done()
   })
 
   it('should serialize and write JSON', function (done) {


### PR DESCRIPTION
This PR fixes #48 failing tests on Node.js v6.x.
I didn't understand why `rimraf()` doesn't call `done` function.
[rimraf](https://github.com/isaacs/rimraf) package passes self tests on Node.js v6.2.1.