### PR TITLE
Switched from default 'fs' module to 'graceful-fs' to prevent EMFILE …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
-var _fs = require('fs')
+var _fs
+try {
+  _fs = require('graceful-fs')
+} catch (_) {
+  _fs = require('fs')
+}
 
 function readFile (file, options, callback) {
   if (callback == null) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
   "dependencies": {},
+  "optionalDependencies": {
+    "graceful-fs": "^4.1.6"
+  },
   "devDependencies": {
     "mocha": "2.x",
     "mock-fs": "^3.8.0",


### PR DESCRIPTION
Switches `fs` module in favor of `graceful-fs` to prevent EMFILE errors. 

See jprichardson/node-fs-extra#275