### PR TITLE
allow overriding the EOL string

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ console.dir(jsonfile.readFileSync(file))
 
 ### writeFile(filename, obj, [options], callback)
 
-`options`: Pass in any `fs.writeFile` options or set `replacer` for a [JSON replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify). Can also pass in `spaces`.
+`options`: Pass in any `fs.writeFile` options or set `replacer` for a [JSON replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify). Can also pass in `spaces` and override `EOL` string.
 
 
 ```js
@@ -84,6 +84,19 @@ jsonfile.writeFile(file, obj, {spaces: 2}, function(err) {
 })
 ```
 
+**overriding EOL:**
+
+```js
+var jsonfile = require('jsonfile')
+
+var file = '/tmp/data.json'
+var obj = {name: 'JP'}
+
+jsonfile.writeFile(file, obj, {spaces: 2, EOL: '\r\n'}, function(err) {
+  console.error(err)
+})
+```
+
 **appending to an existing JSON file:**
 
 You can use `fs.writeFile` option `{flag: 'a'}` to achieve this.
@@ -101,7 +114,7 @@ jsonfile.writeFile(file, obj, {flag: 'a'}, function (err) {
 
 ### writeFileSync(filename, obj, [options])
 
-`options`: Pass in any `fs.writeFileSync` options or set `replacer` for a [JSON replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify). Can also pass in `spaces`.
+`options`: Pass in any `fs.writeFileSync` options or set `replacer` for a [JSON replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify). Can also pass in `spaces` and override `EOL` string.
 
 ```js
 var jsonfile = require('jsonfile')
@@ -121,6 +134,17 @@ var file = '/tmp/data.json'
 var obj = {name: 'JP'}
 
 jsonfile.writeFileSync(file, obj, {spaces: 2})
+```
+
+**overriding EOL:**
+
+```js
+var jsonfile = require('jsonfile')
+
+var file = '/tmp/data.json'
+var obj = {name: 'JP'}
+
+jsonfile.writeFileSync(file, obj, {spaces: 2, EOL: '\r\n'})
 ```
 
 **appending to an existing JSON file:**

--- a/index.js
+++ b/index.js
@@ -77,6 +77,26 @@ function readFileSync (file, options) {
   }
 }
 
+function stringify (obj, options) {
+  // `jsonfile` and not `this` because people might destructure
+  // and use `writeFile` instead of `fs.writeFile`, in which case
+  // `this` would be `undefined`
+  var spaces = jsonfile.spaces
+  var EOL = '\n'
+  if (typeof options === 'object' && options !== null) {
+    if (options.spaces) {
+      spaces = options.spaces
+    }
+    if (options.EOL) {
+      EOL = options.EOL
+    }
+  }
+
+  var str = JSON.stringify(obj, options ? options.replacer : null, spaces)
+
+  return str.replace(/\n/g, EOL) + EOL
+}
+
 function writeFile (file, obj, options, callback) {
   if (callback == null) {
     callback = options
@@ -85,14 +105,9 @@ function writeFile (file, obj, options, callback) {
   options = options || {}
   var fs = options.fs || _fs
 
-  var spaces = typeof options === 'object' && options !== null
-    ? 'spaces' in options
-    ? options.spaces : this.spaces
-    : this.spaces
-
   var str = ''
   try {
-    str = JSON.stringify(obj, options ? options.replacer : null, spaces) + '\n'
+    str = stringify(obj, options)
   } catch (err) {
     // Need to return whether a callback was passed or not
     if (callback) callback(err, null)
@@ -106,12 +121,7 @@ function writeFileSync (file, obj, options) {
   options = options || {}
   var fs = options.fs || _fs
 
-  var spaces = typeof options === 'object' && options !== null
-    ? 'spaces' in options
-    ? options.spaces : this.spaces
-    : this.spaces
-
-  var str = JSON.stringify(obj, options.replacer, spaces) + '\n'
+  var str = stringify(obj, options)
   // not sure if fs.writeFileSync returns anything, but just in case
   return fs.writeFileSync(file, str, options)
 }

--- a/test/write-file-sync.test.js
+++ b/test/write-file-sync.test.js
@@ -78,6 +78,14 @@ describe('+ writeFileSync()', function () {
       var data = fs.readFileSync(file, 'utf8')
       assert.strictEqual(data, JSON.stringify(obj, null, 8) + '\n')
     })
+
+    it('should use EOL override', function () {
+      var file = path.join(TEST_DIR, 'somefile.json')
+      var obj = { name: 'JP' }
+      jf.writeFileSync(file, obj, {spaces: 2, EOL: '***'})
+      var data = fs.readFileSync(file, 'utf8')
+      assert.strictEqual(data, '{***  "name": "JP"***}***')
+    })
   })
 
   describe('> when passing encoding string as options', function () {

--- a/test/write-file.test.js
+++ b/test/write-file.test.js
@@ -104,6 +104,17 @@ describe('+ writeFile()', function () {
         done()
       })
     })
+
+    it('should use EOL override', function (done) {
+      var file = path.join(TEST_DIR, 'somefile.json')
+      var obj = { name: 'jp' }
+      jf.writeFile(file, obj, {spaces: 2, EOL: '***'}, function (err) {
+        assert.ifError(err)
+        var data = fs.readFileSync(file, 'utf8')
+        assert.strictEqual(data, '{***  "name": "jp"***}***')
+        done()
+      })
+    })
   })
 
   describe('> when passing encoding string as options', function () {


### PR DESCRIPTION
Closes #87.

I decided to make it an optional setting as to not cause any grief to anyone. We can always change the default to from `'\n'` to `require('os').EOL` in the future if we want to do a major version bump if we consider it a breaking change.