### PR TITLE
added  j̶s̶m̶i̶n̶ strip-json-comments to process comments in JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ try {
 } catch (_) {
   _fs = require('fs')
 }
+const jsmin = require('jsmin').jsmin
 
 function readFile (file, options, callback) {
   if (callback == null) {
@@ -26,7 +27,7 @@ function readFile (file, options, callback) {
   fs.readFile(file, options, function (err, data) {
     if (err) return callback(err)
 
-    data = stripBom(data)
+    data = jsmin(stripBom(data))
 
     var obj
     try {
@@ -59,7 +60,7 @@ function readFileSync (file, options) {
 
   try {
     var content = fs.readFileSync(file, options)
-    content = stripBom(content)
+    content = jsmin(stripBom(content))
     return JSON.parse(content, options.reviver)
   } catch (err) {
     if (shouldThrow) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ try {
 } catch (_) {
   _fs = require('fs')
 }
-const jsmin = require('jsmin').jsmin
+const stripJsonComments = require('strip-json-comments')
 
 function readFile (file, options, callback) {
   if (callback == null) {
@@ -27,7 +27,7 @@ function readFile (file, options, callback) {
   fs.readFile(file, options, function (err, data) {
     if (err) return callback(err)
 
-    data = jsmin(stripBom(data))
+    data = stripJsonComments(stripBom(data))
 
     var obj
     try {
@@ -60,7 +60,7 @@ function readFileSync (file, options) {
 
   try {
     var content = fs.readFileSync(file, options)
-    content = jsmin(stripBom(content))
+    content = stripJsonComments(stripBom(content))
     return JSON.parse(content, options.reviver)
   } catch (err) {
     if (shouldThrow) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "jsmin": "^1.0.1"
+  },
   "optionalDependencies": {
     "graceful-fs": "^4.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "jsmin": "^1.0.1"
+    "strip-json-comments": "^2.0.1"
   },
   "optionalDependencies": {
     "graceful-fs": "^4.1.6"

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -146,11 +146,11 @@ describe('+ readFileSync()', function () {
     })
   })
 
-    describe('> w/ comments', function () {
+  describe('> w/ comments', function () {
     it('should properly parse', function () {
       var file = path.join(TEST_DIR, 'file-comment.json')
       var obj = { name: 'JP' }
-      fs.writeFileSync(file, JSON.stringify(obj) + "//unnecessary comments")
+      fs.writeFileSync(file, JSON.stringify(obj) + '//unnecessary comments')
       var data = jf.readFileSync(file)
       assert.deepEqual(obj, data)
     })

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -154,5 +154,5 @@ describe('+ readFileSync()', function () {
       var data = jf.readFileSync(file)
       assert.deepEqual(obj, data)
     })
-  })  
+  })
 })

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -145,4 +145,14 @@ describe('+ readFileSync()', function () {
       assert.deepEqual(obj, data)
     })
   })
+
+    describe('> w/ comments', function () {
+    it('should properly parse', function () {
+      var file = path.join(TEST_DIR, 'file-comment.json')
+      var obj = { name: 'JP' }
+      fs.writeFileSync(file, JSON.stringify(obj) + "//unnecessary comments")
+      var data = jf.readFileSync(file)
+      assert.deepEqual(obj, data)
+    })
+  })  
 })

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -179,7 +179,7 @@ describe('+ readFile()', function () {
     it('should properly parse', function (done) {
       var file = path.join(TEST_DIR, 'file-comment.json')
       var obj = { name: 'JP' }
-      fs.writeFileSync(file, JSON.stringify(obj) + "// unnecessary comments")
+      fs.writeFileSync(file, JSON.stringify(obj) + '// unnecessary comments')
       jf.readFile(file, function (err, data) {
         assert.ifError(err)
         assert.deepEqual(obj, data)

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -174,4 +174,17 @@ describe('+ readFile()', function () {
       })
     })
   })
+
+  describe('> w/ comments', function () {
+    it('should properly parse', function (done) {
+      var file = path.join(TEST_DIR, 'file-comment.json')
+      var obj = { name: 'JP' }
+      fs.writeFileSync(file, JSON.stringify(obj) + "// unnecessary comments")
+      jf.readFile(file, function (err, data) {
+        assert.ifError(err)
+        assert.deepEqual(obj, data)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Sometimes JSON files have comments. Crockford recommends [calling jsmin prior to parsing JSON files](https://plus.google.com/+DouglasCrockfordEsq/posts/RK8qyGVaGSr) in order to handle them.