### PR TITLE
feat: make filesystem injectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 node_modules/
 /.project
-/.vscode
-package-lock.json
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 /.project
+/.vscode
+package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -22,6 +22,37 @@ Installation
     npm install --save jsonfile
 
 
+Usage
+-----
+
+Use the default export of `jsonfile` to work with the real on-disk file system.
+
+```js
+const jsonfile = require('jsonfile')
+jsonfile.readFile('/real/disk/location.json', (err, obj) => {
+  if (err) console.error(err)
+  console.dir(obj)
+})
+```
+
+**Advanced Usage**
+
+Use the attached `JsonFile` constructor to create unique instances of the API.
+This is mostly useful when you want to use a virtual or mock filesystem instead of the real filesystem.
+
+The `JsonFile` constructor takes one argument: the underlying `fs` object to use.
+The supplied `fs` must be drop-in compatible with Node's `fs` object.
+Packages like [`memfs`](https://npmjs.com/package/memfs) and [`unionfs`](https://npmjs.com/package/unionfs) would work.
+
+```js
+const memfs = require('memfs')
+const jsonfile = require('jsonfile')
+const jf = new jsonfile.JsonFile(memfs)
+jf.writeFileSync('/virtual.json', { not: 'a real file' });
+jf.readFile('/virtual.json', (err, obj) => {
+  obj.not === 'a real file'
+})
+```
 
 API
 ---

--- a/index.js
+++ b/index.js
@@ -1,137 +1,145 @@
-let _fs
+let realFs
 try {
-  _fs = require('graceful-fs')
+  realFs = require('graceful-fs')
 } catch (_) {
-  _fs = require('fs')
+  realFs = require('fs')
 }
 const universalify = require('universalify')
+const memoize = require('memoize-weak')
 
-function readFileWithCallback (file, options, callback) {
-  if (callback == null) {
-    callback = options
-    options = {}
+const jsonFileFactory = memoize(function jsonFileFactory (_fs) {
+  function readFileWithCallback (file, options, callback) {
+    if (callback == null) {
+      callback = options
+      options = {}
+    }
+
+    if (typeof options === 'string') {
+      options = { encoding: options }
+    }
+
+    options = options || {}
+    const fs = options.fs || _fs
+
+    let shouldThrow = true
+    if ('throws' in options) {
+      shouldThrow = options.throws
+    }
+
+    fs.readFile(file, options, (err, data) => {
+      if (err) return callback(err)
+
+      data = stripBom(data)
+
+      let obj
+      try {
+        obj = JSON.parse(data, options ? options.reviver : null)
+      } catch (err2) {
+        if (shouldThrow) {
+          err2.message = `${file}: ${err2.message}`
+          return callback(err2)
+        } else {
+          return callback(null, null)
+        }
+      }
+
+      callback(null, obj)
+    })
   }
 
-  if (typeof options === 'string') {
-    options = { encoding: options }
-  }
+  const readFile = universalify.fromCallback(readFileWithCallback)
 
-  options = options || {}
-  const fs = options.fs || _fs
+  function readFileSync (file, options) {
+    options = options || {}
+    if (typeof options === 'string') {
+      options = { encoding: options }
+    }
 
-  let shouldThrow = true
-  if ('throws' in options) {
-    shouldThrow = options.throws
-  }
+    const fs = options.fs || _fs
 
-  fs.readFile(file, options, (err, data) => {
-    if (err) return callback(err)
+    let shouldThrow = true
+    if ('throws' in options) {
+      shouldThrow = options.throws
+    }
 
-    data = stripBom(data)
-
-    let obj
     try {
-      obj = JSON.parse(data, options ? options.reviver : null)
-    } catch (err2) {
+      let content = fs.readFileSync(file, options)
+      content = stripBom(content)
+      return JSON.parse(content, options.reviver)
+    } catch (err) {
       if (shouldThrow) {
-        err2.message = `${file}: ${err2.message}`
-        return callback(err2)
+        err.message = `${file}: ${err.message}`
+        throw err
       } else {
-        return callback(null, null)
+        return null
+      }
+    }
+  }
+
+  function stringify (obj, options) {
+    let spaces
+    let EOL = '\n'
+    if (typeof options === 'object' && options !== null) {
+      if (options.spaces) {
+        spaces = options.spaces
+      }
+      if (options.EOL) {
+        EOL = options.EOL
       }
     }
 
-    callback(null, obj)
-  })
-}
+    const str = JSON.stringify(obj, options ? options.replacer : null, spaces)
 
-const readFile = universalify.fromCallback(readFileWithCallback)
-
-function readFileSync (file, options) {
-  options = options || {}
-  if (typeof options === 'string') {
-    options = { encoding: options }
+    return str.replace(/\n/g, EOL) + EOL
   }
 
-  const fs = options.fs || _fs
-
-  let shouldThrow = true
-  if ('throws' in options) {
-    shouldThrow = options.throws
-  }
-
-  try {
-    let content = fs.readFileSync(file, options)
-    content = stripBom(content)
-    return JSON.parse(content, options.reviver)
-  } catch (err) {
-    if (shouldThrow) {
-      err.message = `${file}: ${err.message}`
-      throw err
-    } else {
-      return null
+  function writeFileWithCallback (file, obj, options, callback) {
+    if (callback == null) {
+      callback = options
+      options = {}
     }
-  }
-}
+    options = options || {}
+    const fs = options.fs || _fs
 
-function stringify (obj, options) {
-  let spaces
-  let EOL = '\n'
-  if (typeof options === 'object' && options !== null) {
-    if (options.spaces) {
-      spaces = options.spaces
+    let str = ''
+    try {
+      str = stringify(obj, options)
+    } catch (err) {
+      return callback(err, null)
     }
-    if (options.EOL) {
-      EOL = options.EOL
-    }
+
+    fs.writeFile(file, str, options, callback)
   }
 
-  const str = JSON.stringify(obj, options ? options.replacer : null, spaces)
+  const writeFile = universalify.fromCallback(writeFileWithCallback)
 
-  return str.replace(/\n/g, EOL) + EOL
-}
+  function writeFileSync (file, obj, options) {
+    options = options || {}
+    const fs = options.fs || _fs
 
-function writeFileWithCallback (file, obj, options, callback) {
-  if (callback == null) {
-    callback = options
-    options = {}
-  }
-  options = options || {}
-  const fs = options.fs || _fs
-
-  let str = ''
-  try {
-    str = stringify(obj, options)
-  } catch (err) {
-    return callback(err, null)
+    const str = stringify(obj, options)
+    // not sure if fs.writeFileSync returns anything, but just in case
+    return fs.writeFileSync(file, str, options)
   }
 
-  fs.writeFile(file, str, options, callback)
-}
-
-const writeFile = universalify.fromCallback(writeFileWithCallback)
-
-function writeFileSync (file, obj, options) {
-  options = options || {}
-  const fs = options.fs || _fs
-
-  const str = stringify(obj, options)
-  // not sure if fs.writeFileSync returns anything, but just in case
-  return fs.writeFileSync(file, str, options)
-}
-
-function stripBom (content) {
+  function stripBom (content) {
   // we do this because JSON.parse would convert it to a utf8 string if encoding wasn't specified
-  if (Buffer.isBuffer(content)) content = content.toString('utf8')
-  content = content.replace(/^\uFEFF/, '')
-  return content
+    if (Buffer.isBuffer(content)) content = content.toString('utf8')
+    content = content.replace(/^\uFEFF/, '')
+    return content
+  }
+
+  return {
+    readFile,
+    readFileSync,
+    writeFile,
+    writeFileSync
+  }
+})
+
+function JsonFile (fs = realFs) {
+  Object.assign(this, jsonFileFactory(fs))
 }
 
-const jsonfile = {
-  readFile,
-  readFileSync,
-  writeFile,
-  writeFileSync
-}
-
-module.exports = jsonfile
+module.exports = new JsonFile()
+module.exports.JsonFile = JsonFile

--- a/index.js
+++ b/index.js
@@ -5,9 +5,8 @@ try {
   realFs = require('fs')
 }
 const universalify = require('universalify')
-const memoize = require('memoize-weak')
 
-const jsonFileFactory = memoize(function jsonFileFactory (_fs) {
+function jsonFileFactory (_fs) {
   function readFileWithCallback (file, options, callback) {
     if (callback == null) {
       callback = options
@@ -135,7 +134,7 @@ const jsonFileFactory = memoize(function jsonFileFactory (_fs) {
     writeFile,
     writeFileSync
   }
-})
+}
 
 function JsonFile (fs = realFs) {
   Object.assign(this, jsonFileFactory(fs))

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "universalify": "^0.1.2"
   },
   "optionalDependencies": {
-    "graceful-fs": "^4.1.6"
+    "graceful-fs": "^4.1.6",
+    "memoize-weak": "^1.0.2"
   },
   "devDependencies": {
     "memfs": "^2.16.1",
-    "memoize-weak": "^1.0.2",
     "mocha": "^5.2.0",
     "rimraf": "^2.4.0",
     "standard": "^12.0.1"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "universalify": "^0.1.2"
   },
   "optionalDependencies": {
-    "graceful-fs": "^4.1.6",
-    "memoize-weak": "^1.0.2"
+    "graceful-fs": "^4.1.6"
   },
   "devDependencies": {
     "memfs": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "graceful-fs": "^4.1.6"
   },
   "devDependencies": {
+    "memfs": "^2.16.1",
+    "memoize-weak": "^1.0.2",
     "mocha": "^5.2.0",
     "rimraf": "^2.4.0",
     "standard": "^12.0.1"

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -1,28 +1,22 @@
-const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
 const path = require('path')
-const rimraf = require('rimraf')
-const jf = require('../')
+const assert = require('assert')
+const { Volume, createFsFromVolume } = require('memfs')
+const { JsonFile } = require('../')
 
-/* global describe it beforeEach afterEach */
+/* global describe it beforeEach */
 
 describe('+ readFile()', () => {
-  let TEST_DIR
+  const TEST_DIR = '/'
+  let jf
+  let fs
 
-  beforeEach((done) => {
-    TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-readfile')
-    rimraf.sync(TEST_DIR)
-    fs.mkdir(TEST_DIR, done)
-  })
-
-  afterEach((done) => {
-    rimraf.sync(TEST_DIR)
-    done()
+  beforeEach(() => {
+    fs = createFsFromVolume(new Volume())
+    jf = new JsonFile(fs)
   })
 
   it('should read and parse JSON', (done) => {
-    const file = path.join(TEST_DIR, 'somefile.json')
+    const file = '/somefile.json'
     const obj = { name: 'JP' }
     fs.writeFileSync(file, JSON.stringify(obj))
 
@@ -34,7 +28,7 @@ describe('+ readFile()', () => {
   })
 
   it('should resolve a promise with parsed JSON', (done) => {
-    const file = path.join(TEST_DIR, 'somefile.json')
+    const file = '/somefile.json'
     const obj = { name: 'JP' }
     fs.writeFileSync(file, JSON.stringify(obj))
 
@@ -169,7 +163,7 @@ describe('+ readFile()', () => {
     let file, sillyReviver
 
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'somefile.json')
+      file = '/somefile.json'
       sillyReviver = function (k, v) {
         if (typeof v !== 'string') return v
         if (v.indexOf('date:') < 0) return v
@@ -208,7 +202,7 @@ describe('+ readFile()', () => {
 
   describe('> when passing null as options and callback', () => {
     it('should not throw an error', (done) => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
 
       const obj = {
         name: 'jp'
@@ -225,7 +219,7 @@ describe('+ readFile()', () => {
 
   describe('> when passing null as options and expecting a promise', () => {
     it('should resolve the promise', (done) => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
 
       const obj = {
         name: 'jp'
@@ -248,7 +242,7 @@ describe('+ readFile()', () => {
     let file, obj
 
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'somefile.json')
+      file = '/somefile.json'
 
       obj = {
         name: 'jp'
@@ -282,7 +276,7 @@ describe('+ readFile()', () => {
     let file, obj
 
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'file-bom.json')
+      file = '/file-bom.json'
       obj = { name: 'JP' }
       fs.writeFileSync(file, `\uFEFF${JSON.stringify(obj)}`)
       done()

--- a/test/real-filesystem.test.js
+++ b/test/real-filesystem.test.js
@@ -1,0 +1,79 @@
+const path = require('path')
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const rimraf = require('rimraf')
+const jf = require('..')
+
+/* global describe it beforeEach afterEach */
+
+describe('on real filesystem in temp directory', () => {
+  let TEST_DIR
+
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests')
+    rimraf.sync(TEST_DIR)
+    fs.mkdir(TEST_DIR, done)
+  })
+
+  afterEach(done => {
+    rimraf.sync(TEST_DIR)
+    done()
+  })
+
+  it('readFileSync', () => {
+    const file = path.join(TEST_DIR, 'somefile3.json')
+    const obj = { name: 'JP' }
+    fs.writeFileSync(file, JSON.stringify(obj))
+
+    try {
+      const obj2 = jf.readFileSync(file)
+      assert.strictEqual(obj2.name, obj.name)
+    } catch (err) {
+      assert(err)
+    }
+  })
+
+  it('readFile', (done) => {
+    const file = path.join(TEST_DIR, 'somefile.json')
+    const obj = { name: 'JP' }
+    fs.writeFileSync(file, JSON.stringify(obj))
+
+    jf.readFile(file, (err, obj2) => {
+      assert.ifError(err)
+      assert.strictEqual(obj2.name, obj.name)
+      done()
+    })
+  })
+
+  it('writeFileSync', () => {
+    const file = path.join(TEST_DIR, 'somefile4.json')
+    const obj = { name: 'JP' }
+
+    jf.writeFileSync(file, obj)
+
+    const data = fs.readFileSync(file, 'utf8')
+    const obj2 = JSON.parse(data)
+    assert.strictEqual(obj2.name, obj.name)
+    assert.strictEqual(data[data.length - 1], '\n')
+    assert.strictEqual(data, '{"name":"JP"}\n')
+  })
+
+  it('writeFile', (done) => {
+    const file = path.join(TEST_DIR, 'somefile2.json')
+    const obj = { name: 'JP' }
+
+    jf.writeFile(file, obj, (err) => {
+      assert.ifError(err)
+      fs.readFile(file, 'utf8', (err, data) => {
+        assert.ifError(err)
+        const obj2 = JSON.parse(data)
+        assert.strictEqual(obj2.name, obj.name)
+
+        // verify EOL
+        assert.strictEqual(data[data.length - 1], '\n')
+        done()
+      })
+    })
+  })
+})

--- a/test/write-file-sync.test.js
+++ b/test/write-file-sync.test.js
@@ -1,28 +1,20 @@
 const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const rimraf = require('rimraf')
-const jf = require('../')
+const { Volume, createFsFromVolume } = require('memfs')
+const { JsonFile } = require('../')
 
-/* global describe it beforeEach afterEach */
+/* global describe it beforeEach */
 
 describe('+ writeFileSync()', () => {
-  let TEST_DIR
+  let jf
+  let fs
 
-  beforeEach((done) => {
-    TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-writefile-sync')
-    rimraf.sync(TEST_DIR)
-    fs.mkdir(TEST_DIR, done)
-  })
-
-  afterEach((done) => {
-    rimraf.sync(TEST_DIR)
-    done()
+  beforeEach(() => {
+    fs = createFsFromVolume(new Volume())
+    jf = new JsonFile(fs)
   })
 
   it('should serialize the JSON and write it to file', () => {
-    const file = path.join(TEST_DIR, 'somefile4.json')
+    const file = '/somefile4.json'
     const obj = { name: 'JP' }
 
     jf.writeFileSync(file, obj)
@@ -36,7 +28,7 @@ describe('+ writeFileSync()', () => {
 
   describe('> when JSON replacer is set', () => {
     it('should replace JSON', () => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
       const sillyReplacer = function (k, v) {
         if (!(v instanceof RegExp)) return v
         return `regex:${v.toString()}`
@@ -57,7 +49,7 @@ describe('+ writeFileSync()', () => {
 
   describe('> when spaces passed as an option', () => {
     it('should write file with spaces', () => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
       const obj = { name: 'JP' }
       jf.writeFileSync(file, obj, { spaces: 8 })
       const data = fs.readFileSync(file, 'utf8')
@@ -65,7 +57,7 @@ describe('+ writeFileSync()', () => {
     })
 
     it('should use EOL override', () => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
       const obj = { name: 'JP' }
       jf.writeFileSync(file, obj, { spaces: 2, EOL: '***' })
       const data = fs.readFileSync(file, 'utf8')
@@ -75,7 +67,7 @@ describe('+ writeFileSync()', () => {
 
   describe('> when passing encoding string as options', () => {
     it('should not error', () => {
-      const file = path.join(TEST_DIR, 'somefile6.json')
+      const file = '/somefile6.json'
       const obj = { name: 'jp' }
       jf.writeFileSync(file, obj, 'utf8')
       const data = fs.readFileSync(file, 'utf8')

--- a/test/write-file.test.js
+++ b/test/write-file.test.js
@@ -1,28 +1,20 @@
 const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const rimraf = require('rimraf')
-const jf = require('../')
+const { Volume, createFsFromVolume } = require('memfs')
+const { JsonFile } = require('../')
 
-/* global describe it beforeEach afterEach */
+/* global describe it beforeEach */
 
 describe('+ writeFile()', () => {
-  let TEST_DIR
+  let jf
+  let fs
 
-  beforeEach((done) => {
-    TEST_DIR = path.join(os.tmpdir(), 'jsonfile-tests-writefile')
-    rimraf.sync(TEST_DIR)
-    fs.mkdir(TEST_DIR, done)
-  })
-
-  afterEach((done) => {
-    rimraf.sync(TEST_DIR)
-    done()
+  beforeEach(() => {
+    fs = createFsFromVolume(new Volume())
+    jf = new JsonFile(fs)
   })
 
   it('should serialize and write JSON', (done) => {
-    const file = path.join(TEST_DIR, 'somefile2.json')
+    const file = '/somefile2.json'
     const obj = { name: 'JP' }
 
     jf.writeFile(file, obj, (err) => {
@@ -40,7 +32,7 @@ describe('+ writeFile()', () => {
   })
 
   it('should write JSON, resolve promise', (done) => {
-    const file = path.join(TEST_DIR, 'somefile2.json')
+    const file = '/somefile2.json'
     const obj = { name: 'JP' }
 
     jf.writeFile(file, obj)
@@ -65,7 +57,7 @@ describe('+ writeFile()', () => {
     let file, sillyReplacer, obj
 
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'somefile.json')
+      file = '/somefile.json'
       sillyReplacer = function (k, v) {
         if (!(v instanceof RegExp)) return v
         return `regex:${v.toString()}`
@@ -109,7 +101,7 @@ describe('+ writeFile()', () => {
 
   describe('> when passing null as options and callback', () => {
     it('should not throw an error', (done) => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
       const obj = { name: 'jp' }
       jf.writeFile(file, obj, null, (err) => {
         assert.ifError(err)
@@ -120,7 +112,7 @@ describe('+ writeFile()', () => {
 
   describe('> when passing null as options and No callback', () => {
     it('should not throw an error', (done) => {
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
       const obj = { name: 'jp' }
       jf.writeFile(file, obj, null)
         .then(res => {
@@ -136,7 +128,7 @@ describe('+ writeFile()', () => {
   describe('> when spaces passed as an option', () => {
     let file, obj
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'somefile.json')
+      file = '/somefile.json'
       obj = { name: 'jp' }
       done()
     })
@@ -167,7 +159,7 @@ describe('+ writeFile()', () => {
   describe('> when spaces, EOL are passed as options', () => {
     let file, obj
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'somefile.json')
+      file = '/somefile.json'
       obj = { name: 'jp' }
       done()
     })
@@ -197,7 +189,7 @@ describe('+ writeFile()', () => {
   describe('> when passing encoding string as options', () => {
     let file, obj
     beforeEach((done) => {
-      file = path.join(TEST_DIR, 'somefile.json')
+      file = '/somefile.json'
       obj = { name: 'jp' }
       done()
     })
@@ -229,7 +221,7 @@ describe('+ writeFile()', () => {
   describe("> when callback isn't passed & can't serialize", () => {
     it('should not write an empty file, should reject the promise', function (done) {
       this.slow(1100)
-      const file = path.join(TEST_DIR, 'somefile.json')
+      const file = '/somefile.json'
       const obj1 = { name: 'JP' }
       const obj2 = { person: obj1 }
       obj1.circular = obj2


### PR DESCRIPTION
- User can now inject a `fs` object into an instance of `jsonfile`, to do the same operations on anything that follows the `fs` contract, (such as a Webpack virtual filesystem, for instance).
- Default export is now an instance of the new `JsonFile` constructor, initialized with the default `fs` object. It should work exactly the same as before!
- Tests added for this mode of operation.

Made this to support https://github.com/jprichardson/node-fs-extra/pull/733 to enable the same thing.