### PR TITLE
Use const for EOL variable

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 function stringify (obj, options = {}) {
-  let EOL = options.EOL || '\n'
+  const EOL = options.EOL || '\n'
 
   const str = JSON.stringify(obj, options ? options.replacer : null, options.spaces)
 


### PR DESCRIPTION
The variable is never re-assigned, and using let triggers the following linting error:

```
standard: Use JavaScript Standard Style (https://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.
  /Users/linus/coding/standard/tmp/jsonfile/utils.js:2:7: 'EOL' is never reassigned. Use 'const' instead. (prefer-const)
```

I found this when running the tests in `standard` ☺️ 