### PR TITLE
Upgrade devDependencies to remove npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "mocha": "^5.2.0",
     "rimraf": "^2.4.0",
-    "standard": "^12.0.1"
+    "standard": "^16.0.1"
   },
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "graceful-fs": "^4.1.6"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
+    "mocha": "^8.2.0",
     "rimraf": "^2.4.0",
     "standard": "^16.0.1"
   },

--- a/test/write-file-sync.test.js
+++ b/test/write-file-sync.test.js
@@ -44,7 +44,7 @@ describe('+ writeFileSync()', () => {
 
       const obj = {
         name: 'jp',
-        reg: new RegExp(/hello/g)
+        reg: /hello/g
       }
 
       jf.writeFileSync(file, obj, { replacer: sillyReplacer })

--- a/test/write-file.test.js
+++ b/test/write-file.test.js
@@ -73,7 +73,7 @@ describe('+ writeFile()', () => {
 
       obj = {
         name: 'jp',
-        reg: new RegExp(/hello/g)
+        reg: /hello/g
       }
 
       done()


### PR DESCRIPTION
Upgrade mocha & standard; required minor `standard` fixes in tests.