### PR TITLE
Use "node:" prefixed imports everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,19 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [10.x, 12.x, 14.x, 16.x]
-    runs-on: ubuntu-latest
+        node: [14.18.0, 14, 16.0.0, 16]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          # Node 14 is not available on macos anymore
+          - os: macos-latest
+            node-version: 14
+          - os: macos-latest
+            node-version: 14.18.0
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node }}
     - run: npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,6 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "10"
-    - nodejs_version: "12"
     - nodejs_version: "14"
     - nodejs_version: "16"
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ let _fs
 try {
   _fs = require('graceful-fs')
 } catch (_) {
-  _fs = require('fs')
+  _fs = require('node:fs')
 }
 const universalify = require('universalify')
 const { stringify, stripBom } = require('./utils')

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=14.18.0 <15 || >=16"
+  },
   "dependencies": {
     "universalify": "^2.0.0"
   },

--- a/test/read-file-sync.test.js
+++ b/test/read-file-sync.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const jf = require('../')
 

--- a/test/read-file.test.js
+++ b/test/read-file.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const jf = require('../')
 

--- a/test/write-file-sync.test.js
+++ b/test/write-file-sync.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const jf = require('../')
 

--- a/test/write-file.test.js
+++ b/test/write-file.test.js
@@ -1,7 +1,7 @@
-const assert = require('assert')
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
 const rimraf = require('rimraf')
 const jf = require('../')
 


### PR DESCRIPTION
And bump the minimum nodejs version to the ones that support this.

CI is updated accordingly.

---

Using "node:" prefixed imports enables this library to be used with runtimes other than node which have a node compatibility layer when internal dependencies are prefixed with "node:". Case in point is `workerd`. The cost is raising up the minimum node version to ">=14.18.0 <15 || >=16".