### PR TITLE
Agrega appendToFileSync para fusionar datos en archivos JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,12 +77,25 @@ function writeFileSync (file, obj, options = {}) {
   // not sure if fs.writeFileSync returns anything, but just in case
   return fs.writeFileSync(file, str, options)
 }
+function appendToFileSync (file, newData, options = {}) {
+  let data = {}
+
+  try {
+    data = readFileSync(file, options) || {}
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err
+  }
+
+  const updated = Object.assign({}, data, newData)
+  return writeFileSync(file, updated, options)
+}
 
 const jsonfile = {
   readFile,
   readFileSync,
   writeFile,
-  writeFileSync
+  writeFileSync,
+  appendToFileSync // 👈 ¡nuevo!
 }
 
 module.exports = jsonfile

--- a/test/append-to-file-sync.test.js
+++ b/test/append-to-file-sync.test.js
@@ -1,0 +1,28 @@
+/* global describe, it, afterEach */
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+const jsonfile = require('../index')
+
+const file = path.join(__dirname, 'test-append.json')
+
+describe('appendToFileSync', () => {
+  afterEach(() => {
+    if (fs.existsSync(file)) fs.unlinkSync(file)
+  })
+
+  it('should append data to an existing JSON file', () => {
+    fs.writeFileSync(file, JSON.stringify({ a: 1 }), 'utf8')
+    jsonfile.appendToFileSync(file, { b: 2 })
+
+    const result = JSON.parse(fs.readFileSync(file, 'utf8'))
+    assert.deepStrictEqual(result, { a: 1, b: 2 })
+  })
+
+  it('should create file if it does not exist', () => {
+    jsonfile.appendToFileSync(file, { foo: 'bar' })
+
+    const result = JSON.parse(fs.readFileSync(file, 'utf8'))
+    assert.deepStrictEqual(result, { foo: 'bar' })
+  })
+})


### PR DESCRIPTION
Agregué una nueva función `appendToFileSync(file, newData, options)` que permite leer un archivo JSON existente, combinar su contenido con nuevos datos y escribir el resultado en el mismo archivo.
