### PR TITLE
ESM-compatible exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,11 +78,9 @@ function writeFileSync (file, obj, options = {}) {
   return fs.writeFileSync(file, str, options)
 }
 
-const jsonfile = {
+module.exports = {
   readFile,
   readFileSync,
   writeFile,
   writeFileSync
 }
-
-module.exports = jsonfile

--- a/index.js
+++ b/index.js
@@ -78,6 +78,8 @@ function writeFileSync (file, obj, options = {}) {
   return fs.writeFileSync(file, str, options)
 }
 
+// NOTE: do not change this export format; required for ESM compat
+// see https://github.com/jprichardson/node-jsonfile/pull/162 for details
 module.exports = {
   readFile,
   readFileSync,


### PR DESCRIPTION
Node.js handles ESM-CJS interoperability by using its [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer) to parse CJS files and turn their exports into named exports.  cjs-module-lexer is deliberately limited in its capabilities.  Switching export styles makes jsonfile's exports recognizable by cjs-module-lexer so that ESM code such aborts

```
import { readFileSync } from 'jsonfile'
```

can work as expected, without having to change jsonfile itself to ESM.

Fixes #153